### PR TITLE
Repository move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Version](https://img.shields.io/github/v/release/lendy007/homeassistant-skodaconnect?include_prereleases)
+![Version](https://img.shields.io/github/v/release/skodaconnect/homeassistant-skodaconnect?include_prereleases)
 ![PyPi](https://img.shields.io/pypi/v/skodaconnect?label=latest%20library)
-![Downloads](https://img.shields.io/github/downloads/lendy007/homeassistant-skodaconnect/total)
+![Downloads](https://img.shields.io/github/downloads/skodaconnect/homeassistant-skodaconnect/total)
 
 # **Contributors needed**
 Keeping up with changes made from VAG group to the API requires coders familiar with the code and structure for reverse engineering the changes into this code. Contributions in the form of raised issues and pull requests are much needed in order to maintain the functionality for all different models of Skoda cars.

--- a/custom_components/skodaconnect/__init__.py
+++ b/custom_components/skodaconnect/__init__.py
@@ -2,7 +2,7 @@
 """
 Skoda Connect integration
 
-Read more at https://github.com/lendy007/homeassistant-skodaconnect/
+Read more at https://github.com/skodaconnect/homeassistant-skodaconnect/
 """
 import re
 import asyncio

--- a/custom_components/skodaconnect/manifest.json
+++ b/custom_components/skodaconnect/manifest.json
@@ -1,13 +1,14 @@
 {
     "domain": "skodaconnect",
     "name": "Skoda Connect",
-    "documentation": "https://github.com/lendy007/homeassistant-skodaconnect/blob/main/README.md",
-    "issue_tracker": "https://github.com/lendy007/homeassistant-skodaconnect/issues",
+    "documentation": "https://github.com/skodaconnect/homeassistant-skodaconnect/blob/main/README.md",
+    "issue_tracker": "https://github.com/skodaconnectlendy007/homeassistant-skodaconnect/issues",
     "dependencies": [],
     "config_flow": true,
     "codeowners": [
         "@lendy007",
-        "@Farfar"
+        "@Farfar",
+	"@WebSpider"
     ],
     "requirements": ["skodaconnect>=1.3.5", "homeassistant>=2023.3.0"],
     "version": "v1.2.4",

--- a/info.md
+++ b/info.md
@@ -13,10 +13,10 @@ Please be careful and do NOT install this on production systems. Also make sure 
 {% endif %}
 
 # Changes
-You can find change log under [releases](https://github.com/lendy007/homeassistant-skodaconnect/releases)
+You can find change log under [releases](https://github.com/skodaconnect/homeassistant-skodaconnect/releases)
 
 # Links
-- [Automations](https://github.com/lendy007/homeassistant-skodaconnect/blob/main/README.md#automations)
-- [Change log](https://github.com/lendy007/homeassistant-skodaconnect/releases)
-- [Configuration](https://github.com/lendy007/homeassistant-skodaconnect/blob/main/README.md#configure)
-- [Documentation](https://github.com/lendy007/homeassistant-skodaconnect/blob/main/README.md)
+- [Automations](https://github.com/skodaconnect/homeassistant-skodaconnect/blob/main/README.md#automations)
+- [Change log](https://github.com/skodaconnect/homeassistant-skodaconnect/releases)
+- [Configuration](https://github.com/skodaconnect/homeassistant-skodaconnect/blob/main/README.md#configure)
+- [Documentation](https://github.com/skodaconnect/homeassistant-skodaconnect/blob/main/README.md)


### PR DESCRIPTION
SkodaConnect moved from the original author's private repository to a new organisation. This was done so collaboration is easier in the future and we are less dependant on single persons.

Thanks a lot for being the home for this awesome integration for so long @lendy007 !