### PR TITLE
Releasae 1.2.6 / skodaconnect==1.3.10

### DIFF
--- a/custom_components/skodaconnect/manifest.json
+++ b/custom_components/skodaconnect/manifest.json
@@ -6,11 +6,14 @@
     "dependencies": [],
     "config_flow": true,
     "codeowners": [
-        "@lendy007",
         "@Farfar",
-	"@WebSpider"
+        "@WebSpider",
+        "@dvx76",
     ],
-    "requirements": ["skodaconnect>=1.3.6", "homeassistant>=2023.3.0"],
-    "version": "v1.2.5",
+    "requirements": [
+        "skodaconnect==1.3.10",
+        "homeassistant>=2023.3.0"
+    ],
+    "version": "v1.2.6",
     "iot_class": "cloud_polling"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-skodaconnect>=1.3.6
+skodaconnect==1.3.10
 homeassistant>=2023.3.0


### PR DESCRIPTION
I thought it would be better to pin the exact skodaconnect version for each version of homeassistant-skodaconnect. Let me know what you think.

Depends on skodaconnect==1.3.10 released to PyPI.