### PR TITLE
Release 1.2.9 / skodaconnect==1.3.10

### DIFF
--- a/custom_components/skodaconnect/manifest.json
+++ b/custom_components/skodaconnect/manifest.json
@@ -12,9 +12,9 @@
         "@dvx76"
     ],
     "requirements": [
-        "skodaconnect>=1.3.9",
+        "skodaconnect==1.3.10",
         "homeassistant>=2023.3.0"
     ],
-    "version": "v1.2.8",
+    "version": "v1.2.9",
     "iot_class": "cloud_polling"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-skodaconnect>=1.3.9
+skodaconnect==1.3.10
 homeassistant>=2023.3.0


### PR DESCRIPTION
I thought it would be better to pin the exact skodaconnect version for each version of homeassistant-skodaconnect. Let me know what you think.

Depends on skodaconnect==1.3.10 released to PyPI