### PR TITLE
Add a new state class for odometer

### DIFF
--- a/custom_components/skodaconnect/sensor.py
+++ b/custom_components/skodaconnect/sensor.py
@@ -64,11 +64,16 @@ class SkodaSensor(SkodaEntity, SensorEntity):
     @property
     def state_class(self):
         """Return the state_class for the sensor, to enable statistics"""
-        state_class = None
         if self.instrument.attr in [
             'battery_level', 'adblue_level', 'fuel_level', 'charging_time_left', 'charging_power', 'charge_rate',
             'electric_range', 'combustion_range', 'combined_range', 'outside_temperature'
         ]:
             state_class = "measurement"
+        elif self.instrument.attr in [
+            'odometer'
+        ]:
+            state_class = "total_increasing"
+        else:
+            state_class = None
         return state_class
 

--- a/custom_components/skodaconnect/sensor.py
+++ b/custom_components/skodaconnect/sensor.py
@@ -72,7 +72,7 @@ class SkodaSensor(SkodaEntity, SensorEntity):
         elif self.instrument.attr in [
             'odometer'
         ]:
-            state_class = "total_increasing"
+            state_class = "total"
         else:
             state_class = None
         return state_class


### PR DESCRIPTION
Defining a state class for odometer allows for long-term statistics. Fixes the issue [#213](https://github.com/skodaconnect/homeassistant-skodaconnect/issues/213)

Total: "The state represents a total amount that can both increase and decrease, e.g. a net energy meter."

Examples:

The sensor's value never resets, e.g. a lifetime total energy consumption or production: state_class total, last_reset not set or set to None

https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes