### PR TITLE
Configflow

### DIFF
--- a/custom_components/skodaconnect/config_flow.py
+++ b/custom_components/skodaconnect/config_flow.py
@@ -1,3 +1,4 @@
+import asyncio
 import homeassistant.helpers.config_validation as cv
 import logging
 import voluptuous as vol
@@ -13,11 +14,8 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from skodaconnect import Connection
-from . import get_convert_conf
 from .const import (
     CONF_CONVERT,
-    CONF_SCANDINAVIAN_MILES,
-    CONF_IMPERIAL_UNITS,
     CONF_NO_CONVERSION,
     CONF_DEBUG,
     CONVERT_DICT,
@@ -38,9 +36,9 @@ _LOGGER = logging.getLogger(__name__)
 
 class SkodaConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 3
-    task_login = None
-    task_finish = None
-    task_get_vehicles = None
+    task_login: asyncio.Task | None = None
+    task_finish: asyncio.Task | None = None
+    task_get_vehicles: asyncio.Task | None = None
     entry = None
 
     def __init__(self):
@@ -195,14 +193,15 @@ class SkodaConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    # Authentication and login
     async def async_step_login(self, user_input=None):
+        """Authentication and login."""
         if not self.task_login:
             self.task_login = self.hass.async_create_task(self._async_task_login())
 
             return self.async_show_progress(
                 step_id="login",
                 progress_action="task_login",
+                progress_task=self.task_login,
             )
 
         # noinspection PyBroadException
@@ -218,13 +217,16 @@ class SkodaConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_get_vehicles()
 
     async def async_step_get_vehicles(self, user_input=None):
+        """Get vehicles step."""
         if not self.task_get_vehicles:
             self.task_get_vehicles = self.hass.async_create_task(
                 self._async_task_get_vehicles()
             )
 
             return self.async_show_progress(
-                step_id="get_vehicles", progress_action="task_get_vehicles"
+                step_id="get_vehicles",
+                progress_action="task_get_vehicles",
+                progress_task=self.task_get_vehicles,
             )
 
         # noinspection PyBroadException


### PR DESCRIPTION
First commits are black formatting only and bumping the HA version. Actual fix is in the last commit so you probably want to focus on that while reviewing.

Fixes the following warning:

```
custom_components.skodaconnect.config_flow::SkodaConnectConfigFlow calls async_show_progress without passing a progress task, this is not valid and will break in Home Assistant Core 2024.8. Please report it to the custom integration author
```

Reference: https://developers.home-assistant.io/docs/data_entry_flow_index/

Tested configuration flow on HA Core 2024.4.3. No more warning and can pass configuration.

Fixes #268 